### PR TITLE
fix:Added vercel.json file to avoid 404 error on page refresh

### DIFF
--- a/client-user/vercel.json
+++ b/client-user/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
When the client is refreshed in the live link, the page returns a 404 error
![image](https://github.com/Jeysiva-apjs/LearnAcademy-OpenSource/assets/103611443/ebc84c50-c104-4d4e-a34f-ca17f75d21da)
